### PR TITLE
(Fix) Add logic for escaping column names

### DIFF
--- a/Functions/Table/ToM.pq
+++ b/Functions/Table/ToM.pq
@@ -119,7 +119,11 @@ let
       ColTypes_Text = Text.Combine(
         List.Transform(
           Table.ToRecords(Schema),
-          each [Name] & " = " & [Kind]
+          each
+            if (Text.Select([Name], {"0".."9", "a".."z", "A".."Z"} ) = [Name])
+              and List.Contains({"a".."z", "A".."Z"}, Text.Start([Name], 1))
+            then [Name] & " = " & [Kind]
+            else "#""" & [Name] & """ = " & [Kind]
         ), 
         ", "
       ), 
@@ -157,4 +161,3 @@ let
 in
   // Apply the function metadata to myFunction.
   Value.ReplaceType(myFunction, metaDocumentation)
-  


### PR DESCRIPTION
If a column name has spaces or special characters, it needs to be wrapped with #" ". This update is needed to prevent errors.